### PR TITLE
[DO NOT MERGE] Slow down player max speed.

### DIFF
--- a/internal/game/player/player.go
+++ b/internal/game/player/player.go
@@ -118,7 +118,7 @@ const (
 	// g = 576
 	// Note: assuming 1px=6cm, this is actually 17.3m/s and 3.5x earth gravity.
 	JumpVelocity = 288 * constants.SubPixelScale / engine.GameTPS
-	MaxSpeed     = 2 * level.TileSize * constants.SubPixelScale
+	MaxSpeed     = 7 * level.TileSize * constants.SubPixelScale / 4
 
 	// Scale noise by speed.
 	NoiseMinSpeed = 384 * constants.SubPixelScale / engine.GameTPS


### PR DESCRIPTION
Just to make the 100% regression test fail.