### PR TITLE
Do not allow respawning the player during entity processing.

### DIFF
--- a/internal/game/misc/movinganimation.go
+++ b/internal/game/misc/movinganimation.go
@@ -94,7 +94,7 @@ func (s *MovingAnimation) Touch(other *engine.Entity) {
 	}
 	if other == s.World.Player {
 		if s.RespawnOnTouch {
-			s.World.RespawnPlayer(s.World.PlayerState.LastCheckpoint(), false)
+			s.World.ScheduleRespawnPlayer(s.World.PlayerState.LastCheckpoint(), false)
 		}
 	} else {
 		if s.FadeOnTouch {

--- a/internal/game/trigger/respawn_player.go
+++ b/internal/game/trigger/respawn_player.go
@@ -61,7 +61,7 @@ func (r *RespawnPlayer) Touch(other *engine.Entity) {
 	if other != r.World.Player {
 		return
 	}
-	r.World.RespawnPlayer(r.World.PlayerState.LastCheckpoint(), false)
+	r.World.ScheduleRespawnPlayer(r.World.PlayerState.LastCheckpoint(), false)
 }
 
 func init() {

--- a/internal/menu/menu.go
+++ b/internal/menu/menu.go
@@ -359,7 +359,7 @@ func (c *Controller) SwitchToCheckpoint(cp string) error {
 	if cp != c.World.PlayerState.LastCheckpoint() {
 		c.World.PlayerState.AddTeleport()
 	}
-	err := c.World.RespawnPlayer(cp, true)
+	err := c.World.RespawnPlayerImmediately(cp, true)
 	if err != nil {
 		return fmt.Errorf("could not respawn player: %w", err)
 	}


### PR DESCRIPTION
Instead schedule the respawn for after the current frame.

Fixes #496.