### PR TITLE
Fix startup crash when current working directory doesn't match exeDir

### DIFF
--- a/internal/vfs/assets_fs_local.go
+++ b/internal/vfs/assets_fs_local.go
@@ -25,23 +25,29 @@ import (
 
 // initAssets initializes the VFS.
 func initAssetsFS() ([]fsRoot, error) {
+	assetsPath := filepath.Join(exeDir, "assets")
+	thirdPartyPath := filepath.Join(exeDir, "third_party")
+	licensesPath := filepath.Join(exeDir, "licenses")
+
 	dirs := []fsRoot{
 		{
-			name:     "local:" + "assets",
-			filesys:  os.DirFS("assets"),
+			name:     "local:assets",
+			filesys:  os.DirFS(assetsPath),
 			root:     ".",
 			toPrefix: "/",
 		},
 	}
-	content, err := os.ReadDir("third_party")
+
+	content, err := os.ReadDir(thirdPartyPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not find local third party directory: %v", err)
 	}
+
 	for _, info := range content {
 		if !info.IsDir() {
 			continue
 		}
-		path := filepath.Join("third_party", info.Name(), "assets")
+		path := filepath.Join(thirdPartyPath, info.Name(), "assets")
 		dirs = append(dirs, fsRoot{
 			name:     "local:" + path,
 			filesys:  os.DirFS(path),
@@ -49,11 +55,13 @@ func initAssetsFS() ([]fsRoot, error) {
 			toPrefix: "/",
 		})
 	}
+
 	dirs = append(dirs, fsRoot{
 		name:     "embed:licenses",
-		filesys:  os.DirFS("licenses"),
+		filesys:  os.DirFS(licensesPath),
 		root:     ".",
 		toPrefix: "/licenses/",
 	})
+
 	return dirs, nil
 }


### PR DESCRIPTION
The game crashes on startup when the shell's working directory is not the same as where the executable is built. For example
1. cd
2. git clone https://github.com/divVerent/aaaaxy
3. cd aaaaxy
4. make
5. cd ..
6. aaaaxy/aaaaxy
goroutine 1 [running, locked to thread]:
runtime/debug.Stack()
	/home/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.13.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
	/home/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.13.linux-amd64/src/runtime/debug/stack.go:18 +0x13
github.com/divVerent/aaaaxy/internal/log.Fatalf({0xa6a400, 0x1d}, {0xc0005e3f18, 0x1, 0x1})
	/home/user/aaaaxy/internal/log/log.go:101 +0x3f
main.main()
	/home/user/aaaaxy/main.go:143 +0x125
2026/08/18 11:29:13.524895 [FATAL] could not initialize game: could not initialize VFS: could not find local third party directory: open third_party: no such file or directory