### PR TITLE
Shrink checkpoint for Multi Party Authorization

### DIFF
--- a/assets/maps/level.tmx
+++ b/assets/maps/level.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.12.2" orientation="orthogonal" renderorder="right-down" width="512" height="512" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="8607">
+<map version="1.8" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="512" height="512" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="8609">
  <properties>
   <property name="checkpoint_locations_hash" value="15679952859001470231"/>
   <property name="credits_music" value="Juhani Junkala [Retro Game Music Pack] Ending.ogg"/>
@@ -8331,7 +8331,7 @@
    </properties>
   </object>
   <object id="2990" gid="305" x="4064" y="3232" width="32" height="32"/>
-  <object id="2992" name="push_me_not" type="Checkpoint" x="4000" y="3136" width="64" height="64">
+  <object id="2992" name="push_me_not" type="Checkpoint" x="4000" y="3136" width="32" height="64">
    <properties>
     <property name="_text_localization_note" value="May also be known as 'for eyes principle'; a concept from IT security. This part of the level focuses on the need for multiple switches being toggled on by two platforms simultaneously to make progress."/>
     <property name="music" value="AugustUltraAmbience.ogg"/>
@@ -20032,5 +20032,7 @@
     <property name="unless_won" type="bool" value="true"/>
    </properties>
   </object>
+  <object id="8607" name="ShortStairsWarp" gid="299" x="3952" y="3168" width="16" height="32"/>
+  <object id="8608" name="ShortStairsWarp" gid="293" x="3904" y="3168" width="16" height="32"/>
  </objectgroup>
 </map>

--- a/assets/maps/level.tmx
+++ b/assets/maps/level.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="512" height="512" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="8606">
+<map version="1.8" tiledversion="1.12.2" orientation="orthogonal" renderorder="right-down" width="512" height="512" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="8606">
  <properties>
   <property name="checkpoint_locations_hash" value="15679952859001470231"/>
   <property name="credits_music" value="Juhani Junkala [Retro Game Music Pack] Ending.ogg"/>
@@ -8326,7 +8326,7 @@
    </properties>
   </object>
   <object id="2990" gid="305" x="4064" y="3232" width="32" height="32"/>
-  <object id="2992" name="push_me_not" type="Checkpoint" x="4000" y="3136" width="96" height="64">
+  <object id="2992" name="push_me_not" type="Checkpoint" x="4000" y="3136" width="64" height="64">
    <properties>
     <property name="_text_localization_note" value="May also be known as 'for eyes principle'; a concept from IT security. This part of the level focuses on the need for multiple switches being toggled on by two platforms simultaneously to make progress."/>
     <property name="music" value="AugustUltraAmbience.ogg"/>


### PR DESCRIPTION
The checkpoint for Multi Party Authorization is a bit misleading,
I got very confused on my second playthrough about the note that
says "Lack of purpose never was a reason not to do it."
because I saw that Pushing Onwards had 2/3 notes and I kept
thinking that the note has to be in the section with the white background :P
When you hit the checkpoint coming from Pushing Onwards, you think
"It can't be this way anymore"
so would making the checkpoint smaller here be ok?